### PR TITLE
Runtime improvements for CostmapToPolygonsDBSMCCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,11 @@ install(DIRECTORY
 ## Testing ##
 #############
 
+catkin_add_gtest(costmap_polygons test/costmap_polygons.cpp)
+if(TARGET costmap_polygons)
+   target_link_libraries(costmap_polygons costmap_converter)
+endif()
+
 ## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_drawing.cpp)
 # if(TARGET ${PROJECT_NAME}-test)

--- a/include/costmap_converter/costmap_to_polygons.h
+++ b/include/costmap_converter/costmap_to_polygons.h
@@ -265,24 +265,35 @@ class CostmapToPolygonsDBSMCCH : public BaseCostmapToPolygons
    
    std::vector<KeyPoint> occupied_cells_; //!< List of occupied cells in the current map (updated by updateCostmap2D())
    
-   std::vector<std::vector<int> > neighbor_lookup_; //! array of cells for neighbor lookup
-   int neighbor_size_x_;
-   int neighbor_size_y_;
-   double offset_x_;
-   double offset_y_;
+    std::vector<std::vector<int> > neighbor_lookup_; //! array of cells for neighbor lookup
+    int neighbor_size_x_; //! size of the neighbour lookup in x (number of cells)
+    int neighbor_size_y_; //! size of the neighbour lookup in y (number of cells)
+    double offset_x_;     //! offset [meters] in x for the lookup grid
+    double offset_y_;     //! offset [meters] in y for the lookup grid
 
-   int neighborCellsToIndex(int cx, int cy)
-   {
-     if (cx < 0 || cx >= neighbor_size_x_ || cy < 0 || cy >= neighbor_size_y_)
-       return -1;
-     return cy * neighbor_size_x_ + cx;
-   }
+    /**
+      * @brief convert a 2d cell coordinate into the 1D index of the array
+      * @param cx the x index of the cell
+      * @param cy the y index of the cell
+      */
+    int neighborCellsToIndex(int cx, int cy)
+    {
+      if (cx < 0 || cx >= neighbor_size_x_ || cy < 0 || cy >= neighbor_size_y_)
+        return -1;
+      return cy * neighbor_size_x_ + cx;
+    }
 
-   int pointToNeighborCells(const KeyPoint& kp, int& cx, int& cy)
-   {
-     cx = int((kp.x - offset_x_) / parameter_.max_distance_);
-     cy = int((kp.y - offset_y_) / parameter_.max_distance_);
-   }
+    /**
+      * @brief compute the cell indices of a keypoint
+      * @param kp key point given in world coordinates [m, m]
+      * @param cx output cell index in x direction
+      * @param cy output cell index in y direction
+      */
+    int pointToNeighborCells(const KeyPoint& kp, int& cx, int& cy)
+    {
+      cx = int((kp.x - offset_x_) / parameter_.max_distance_);
+      cy = int((kp.y - offset_y_) / parameter_.max_distance_);
+    }
 
 
     Parameters parameter_;          //< active parameters throughout computation

--- a/src/costmap_to_lines_convex_hull.cpp
+++ b/src/costmap_to_lines_convex_hull.cpp
@@ -61,18 +61,19 @@ CostmapToLinesDBSMCCH::~CostmapToLinesDBSMCCH()
 void CostmapToLinesDBSMCCH::initialize(ros::NodeHandle nh)
 { 
     // DB SCAN
-    max_distance_ = 0.4; 
-    nh.param("cluster_max_distance", max_distance_, max_distance_);
+    parameter_.max_distance_ = 0.4; 
+    nh.param("cluster_max_distance", parameter_.max_distance_, parameter_.max_distance_);
     
-    min_pts_ = 2;
-    nh.param("cluster_min_pts", min_pts_, min_pts_);
+    parameter_.min_pts_ = 2;
+    nh.param("cluster_min_pts", parameter_.min_pts_, parameter_.min_pts_);
     
-    max_pts_ = 30;
-    nh.param("cluster_max_pts", max_pts_, max_pts_);
+    parameter_.max_pts_ = 30;
+    nh.param("cluster_max_pts", parameter_.max_pts_, parameter_.max_pts_);
     
     // convex hull
-    min_keypoint_separation_ = 0.1;
-    nh.param("convex_hull_min_pt_separation", min_keypoint_separation_, min_keypoint_separation_);
+    parameter_.min_keypoint_separation_ = 0.1;
+    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, parameter_.min_keypoint_separation_);
+    parameter_buffered_ = parameter_;
     
     // Line extraction
     support_pts_max_dist_ = 0.3;
@@ -99,7 +100,7 @@ void CostmapToLinesDBSMCCH::initialize(ros::NodeHandle nh)
 void CostmapToLinesDBSMCCH::compute()
 {
     std::vector< std::vector<KeyPoint> > clusters;
-    dbScan(occupied_cells_, clusters);
+    dbScan(clusters);
     
     // Create new polygon container
     PolygonContainerPtr polygons(new std::vector<geometry_msgs::Polygon>());  
@@ -283,10 +284,11 @@ void CostmapToLinesDBSMCCH::extractPointsAndLines(std::vector<KeyPoint>& cluster
 
 void CostmapToLinesDBSMCCH::reconfigureCB(CostmapToLinesDBSMCCHConfig& config, uint32_t level)
 {
-    max_distance_ = config.cluster_max_distance;
-    min_pts_ = config.cluster_min_pts;
-    max_pts_ = config.cluster_max_pts;
-    min_keypoint_separation_ = config.cluster_min_pts;
+    boost::mutex::scoped_lock lock(parameter_mutex_);
+    parameter_buffered_.max_distance_ = config.cluster_max_distance;
+    parameter_buffered_.min_pts_ = config.cluster_min_pts;
+    parameter_buffered_.max_pts_ = config.cluster_max_pts;
+    parameter_buffered_.min_keypoint_separation_ = config.cluster_min_pts;
     support_pts_max_dist_ = config.support_pts_max_dist;
     support_pts_max_dist_inbetween_ = config.support_pts_max_dist_inbetween;
     min_support_pts_ = config.min_support_pts;

--- a/src/costmap_to_lines_convex_hull.cpp
+++ b/src/costmap_to_lines_convex_hull.cpp
@@ -61,29 +61,17 @@ CostmapToLinesDBSMCCH::~CostmapToLinesDBSMCCH()
 void CostmapToLinesDBSMCCH::initialize(ros::NodeHandle nh)
 { 
     // DB SCAN
-    parameter_.max_distance_ = 0.4; 
-    nh.param("cluster_max_distance", parameter_.max_distance_, parameter_.max_distance_);
-    
-    parameter_.min_pts_ = 2;
-    nh.param("cluster_min_pts", parameter_.min_pts_, parameter_.min_pts_);
-    
-    parameter_.max_pts_ = 30;
-    nh.param("cluster_max_pts", parameter_.max_pts_, parameter_.max_pts_);
-    
+    nh.param("cluster_max_distance", parameter_.max_distance_, 0.4);
+    nh.param("cluster_min_pts", parameter_.min_pts_, 2);
+    nh.param("cluster_max_pts", parameter_.max_pts_, 30);
     // convex hull
-    parameter_.min_keypoint_separation_ = 0.1;
-    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, parameter_.min_keypoint_separation_);
+    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, 0.1);
     parameter_buffered_ = parameter_;
     
     // Line extraction
-    support_pts_max_dist_ = 0.3;
-    nh.param("support_pts_max_dist", support_pts_max_dist_, support_pts_max_dist_);
-    
-    support_pts_max_dist_inbetween_ = 1.0;
-    nh.param("support_pts_max_dist_inbetween", support_pts_max_dist_inbetween_, support_pts_max_dist_inbetween_);
-    
-    min_support_pts_ = 2;
-    nh.param("min_support_pts", min_support_pts_, min_support_pts_);
+    nh.param("support_pts_max_dist", support_pts_max_dist_, 0.3);
+    nh.param("support_pts_max_dist_inbetween", support_pts_max_dist_inbetween_, 1.0);
+    nh.param("min_support_pts", min_support_pts_, 2);
     
     // setup dynamic reconfigure
     dynamic_recfg_ = new dynamic_reconfigure::Server<CostmapToLinesDBSMCCHConfig>(nh);

--- a/src/costmap_to_lines_ransac.cpp
+++ b/src/costmap_to_lines_ransac.cpp
@@ -60,14 +60,19 @@ CostmapToLinesDBSRANSAC::~CostmapToLinesDBSRANSAC()
 void CostmapToLinesDBSRANSAC::initialize(ros::NodeHandle nh)
 { 
     // DB SCAN
-    max_distance_ = 0.4; 
-    nh.param("cluster_max_distance", max_distance_, max_distance_);
+    parameter_.max_distance_ = 0.4; 
+    nh.param("cluster_max_distance", parameter_.max_distance_, parameter_.max_distance_);
     
-    min_pts_ = 2;
-    nh.param("cluster_min_pts", min_pts_, min_pts_);
+    parameter_.min_pts_ = 2;
+    nh.param("cluster_min_pts", parameter_.min_pts_, parameter_.min_pts_);
     
-    max_pts_ = 30;
-    nh.param("cluster_max_pts", max_pts_, max_pts_);
+    parameter_.max_pts_ = 30;
+    nh.param("cluster_max_pts", parameter_.max_pts_, parameter_.max_pts_);
+    
+    // convex hull (only necessary if outlier filtering is enabled)
+    parameter_.min_keypoint_separation_ = 0.1;
+    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, parameter_.min_keypoint_separation_);
+    parameter_buffered_ = parameter_;
 
     // ransac
     ransac_inlier_distance_ = 0.2;
@@ -88,10 +93,6 @@ void CostmapToLinesDBSRANSAC::initialize(ros::NodeHandle nh)
     ransac_filter_remaining_outlier_pts_ = false;
     nh.param("ransac_filter_remaining_outlier_pts", ransac_filter_remaining_outlier_pts_, ransac_filter_remaining_outlier_pts_);
     
-    // convex hull (only necessary if outlier filtering is enabled)
-    min_keypoint_separation_ = 0.1;
-    nh.param("convex_hull_min_pt_separation", min_keypoint_separation_, min_keypoint_separation_);
-    
     // setup dynamic reconfigure
     dynamic_recfg_ = new dynamic_reconfigure::Server<CostmapToLinesDBSRANSACConfig>(nh);
     dynamic_reconfigure::Server<CostmapToLinesDBSRANSACConfig>::CallbackType cb = boost::bind(&CostmapToLinesDBSRANSAC::reconfigureCB, this, _1, _2);
@@ -101,7 +102,7 @@ void CostmapToLinesDBSRANSAC::initialize(ros::NodeHandle nh)
 void CostmapToLinesDBSRANSAC::compute()
 {
     std::vector< std::vector<KeyPoint> > clusters;
-    dbScan(occupied_cells_, clusters);
+    dbScan(clusters);
     
     // Create new polygon container
     PolygonContainerPtr polygons(new std::vector<geometry_msgs::Polygon>());  
@@ -297,16 +298,17 @@ bool CostmapToLinesDBSRANSAC::linearRegression(const std::vector<KeyPoint>& data
 
 void CostmapToLinesDBSRANSAC::reconfigureCB(CostmapToLinesDBSRANSACConfig& config, uint32_t level)
 {
-    max_distance_ = config.cluster_max_distance;
-    min_pts_ = config.cluster_min_pts;
-    max_pts_ = config.cluster_max_pts;
+    boost::mutex::scoped_lock lock(parameter_mutex_);
+    parameter_buffered_.max_distance_ = config.cluster_max_distance;
+    parameter_buffered_.min_pts_ = config.cluster_min_pts;
+    parameter_buffered_.max_pts_ = config.cluster_max_pts;
+    parameter_buffered_.min_keypoint_separation_ = config.cluster_min_pts;
     ransac_inlier_distance_ = config.ransac_inlier_distance;
     ransac_min_inliers_ = config.ransac_min_inliers;
     ransac_no_iterations_ = config.ransac_no_iterations;
     ransac_remainig_outliers_ = config.ransac_remainig_outliers;
     ransac_convert_outlier_pts_ = config.ransac_convert_outlier_pts;
     ransac_filter_remaining_outlier_pts_ = config.ransac_filter_remaining_outlier_pts;
-    min_keypoint_separation_ = config.cluster_min_pts;
 }
 
 

--- a/src/costmap_to_lines_ransac.cpp
+++ b/src/costmap_to_lines_ransac.cpp
@@ -60,38 +60,20 @@ CostmapToLinesDBSRANSAC::~CostmapToLinesDBSRANSAC()
 void CostmapToLinesDBSRANSAC::initialize(ros::NodeHandle nh)
 { 
     // DB SCAN
-    parameter_.max_distance_ = 0.4; 
-    nh.param("cluster_max_distance", parameter_.max_distance_, parameter_.max_distance_);
-    
-    parameter_.min_pts_ = 2;
-    nh.param("cluster_min_pts", parameter_.min_pts_, parameter_.min_pts_);
-    
-    parameter_.max_pts_ = 30;
-    nh.param("cluster_max_pts", parameter_.max_pts_, parameter_.max_pts_);
-    
+    nh.param("cluster_max_distance", parameter_.max_distance_, 0.4);
+    nh.param("cluster_min_pts", parameter_.min_pts_, 2);
+    nh.param("cluster_max_pts", parameter_.max_pts_, 30);
     // convex hull (only necessary if outlier filtering is enabled)
-    parameter_.min_keypoint_separation_ = 0.1;
-    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, parameter_.min_keypoint_separation_);
+    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, 0.1);
     parameter_buffered_ = parameter_;
 
     // ransac
-    ransac_inlier_distance_ = 0.2;
-    nh.param("ransac_inlier_distance", ransac_inlier_distance_, ransac_inlier_distance_);
-    
-    ransac_min_inliers_ = 10;
-    nh.param("ransac_min_inliers", ransac_min_inliers_, ransac_min_inliers_);
-    
-    ransac_no_iterations_ = 2000;
-    nh.param("ransac_no_iterations", ransac_no_iterations_, ransac_no_iterations_);
-   
-    ransac_remainig_outliers_ = 3;
-    nh.param("ransac_remainig_outliers", ransac_remainig_outliers_, ransac_remainig_outliers_);
-    
-    ransac_convert_outlier_pts_ = true;
-    nh.param("ransac_convert_outlier_pts", ransac_convert_outlier_pts_, ransac_convert_outlier_pts_);
-    
-    ransac_filter_remaining_outlier_pts_ = false;
-    nh.param("ransac_filter_remaining_outlier_pts", ransac_filter_remaining_outlier_pts_, ransac_filter_remaining_outlier_pts_);
+    nh.param("ransac_inlier_distance", ransac_inlier_distance_, 0.2);
+    nh.param("ransac_min_inliers", ransac_min_inliers_, 10);
+    nh.param("ransac_no_iterations", ransac_no_iterations_, 2000);
+    nh.param("ransac_remainig_outliers", ransac_remainig_outliers_, 3);
+    nh.param("ransac_convert_outlier_pts", ransac_convert_outlier_pts_, true);
+    nh.param("ransac_filter_remaining_outlier_pts", ransac_filter_remaining_outlier_pts_, false);
     
     // setup dynamic reconfigure
     dynamic_recfg_ = new dynamic_reconfigure::Server<CostmapToLinesDBSRANSACConfig>(nh);

--- a/src/costmap_to_polygons.cpp
+++ b/src/costmap_to_polygons.cpp
@@ -64,17 +64,10 @@ void CostmapToPolygonsDBSMCCH::initialize(ros::NodeHandle nh)
 {
     costmap_ = NULL;
    
-    parameter_.max_distance_ = 0.4; 
-    nh.param("cluster_max_distance", parameter_.max_distance_, parameter_.max_distance_);
-    
-    parameter_.min_pts_ = 2;
-    nh.param("cluster_min_pts", parameter_.min_pts_, parameter_.min_pts_);
-    
-    parameter_.max_pts_ = 30;
-    nh.param("cluster_max_pts", parameter_.max_pts_, parameter_.max_pts_);
-    
-    parameter_.min_keypoint_separation_ = 0.1;
-    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, parameter_.min_keypoint_separation_);
+    nh.param("cluster_max_distance", parameter_.max_distance_, 0.4);
+    nh.param("cluster_min_pts", parameter_.min_pts_, 2);
+    nh.param("cluster_max_pts", parameter_.max_pts_, 30);
+    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, 0.1);
     
     parameter_buffered_ = parameter_;
     

--- a/src/costmap_to_polygons.cpp
+++ b/src/costmap_to_polygons.cpp
@@ -415,9 +415,10 @@ void CostmapToPolygonsDBSMCCH::convexHull2(std::vector<KeyPoint>& cluster, geome
     
     if (parameter_.min_keypoint_separation_>0) // TODO maybe migrate to algorithm above to speed up computation
     {
+      double keypoint_sep_sqr = std::pow(parameter_.min_keypoint_separation_, 2);
       for (int i=0; i < (int) polygon.points.size() - 1; ++i)
       {
-        if ( std::sqrt(std::pow((polygon.points[i].x - polygon.points[i+1].x),2) + std::pow((polygon.points[i].y - polygon.points[i+1].y),2)) < parameter_.min_keypoint_separation_ )
+        if ( std::pow((polygon.points[i].x - polygon.points[i+1].x),2) + std::pow((polygon.points[i].y - polygon.points[i+1].y),2) < keypoint_sep_sqr )
           polygon.points.erase(polygon.points.begin()+i+1);
       }
     }

--- a/src/costmap_to_polygons_concave.cpp
+++ b/src/costmap_to_polygons_concave.cpp
@@ -58,17 +58,18 @@ CostmapToPolygonsDBSConcaveHull::~CostmapToPolygonsDBSConcaveHull()
 
 void CostmapToPolygonsDBSConcaveHull::initialize(ros::NodeHandle nh)
 {
-    max_distance_ = 0.4; 
-    nh.param("cluster_max_distance", max_distance_, max_distance_);
+    parameter_.max_distance_ = 0.4; 
+    nh.param("cluster_max_distance", parameter_.max_distance_, parameter_.max_distance_);
     
-    min_pts_ = 2;
-    nh.param("cluster_min_pts", min_pts_, min_pts_);
+    parameter_.min_pts_ = 2;
+    nh.param("cluster_min_pts", parameter_.min_pts_, parameter_.min_pts_);
     
-    max_pts_ = 30;
-    nh.param("cluster_max_pts", max_pts_, max_pts_);
+    parameter_.max_pts_ = 30;
+    nh.param("cluster_max_pts", parameter_.max_pts_, parameter_.max_pts_);
     
-    min_keypoint_separation_ = 0.1;
-    nh.param("convex_hull_min_pt_separation", min_keypoint_separation_, min_keypoint_separation_);
+    parameter_.min_keypoint_separation_ = 0.1;
+    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, parameter_.min_keypoint_separation_);
+    parameter_buffered_ = parameter_;
     
     concave_hull_depth_ = 2.0;
     nh.param("concave_hull_depth", concave_hull_depth_, concave_hull_depth_);
@@ -83,7 +84,7 @@ void CostmapToPolygonsDBSConcaveHull::initialize(ros::NodeHandle nh)
 void CostmapToPolygonsDBSConcaveHull::compute()
 {
     std::vector< std::vector<KeyPoint> > clusters;
-    dbScan(occupied_cells_, clusters);
+    dbScan(clusters);
     
     // Create new polygon container
     PolygonContainerPtr polygons(new std::vector<geometry_msgs::Polygon>());
@@ -214,10 +215,11 @@ void CostmapToPolygonsDBSConcaveHull::concaveHullClusterCut(std::vector<KeyPoint
 
 void CostmapToPolygonsDBSConcaveHull::reconfigureCB(CostmapToPolygonsDBSConcaveHullConfig& config, uint32_t level)
 {
-    max_distance_ = config.cluster_max_distance;
-    min_pts_ = config.cluster_min_pts;
-    max_pts_ = config.cluster_max_pts;
-    min_keypoint_separation_ = config.cluster_min_pts;
+    boost::mutex::scoped_lock lock(parameter_mutex_);
+    parameter_buffered_.max_distance_ = config.cluster_max_distance;
+    parameter_buffered_.min_pts_ = config.cluster_min_pts;
+    parameter_buffered_.max_pts_ = config.cluster_max_pts;
+    parameter_buffered_.min_keypoint_separation_ = config.cluster_min_pts;
     concave_hull_depth_ = config.concave_hull_depth;
 }
 

--- a/src/costmap_to_polygons_concave.cpp
+++ b/src/costmap_to_polygons_concave.cpp
@@ -58,21 +58,13 @@ CostmapToPolygonsDBSConcaveHull::~CostmapToPolygonsDBSConcaveHull()
 
 void CostmapToPolygonsDBSConcaveHull::initialize(ros::NodeHandle nh)
 {
-    parameter_.max_distance_ = 0.4; 
-    nh.param("cluster_max_distance", parameter_.max_distance_, parameter_.max_distance_);
-    
-    parameter_.min_pts_ = 2;
-    nh.param("cluster_min_pts", parameter_.min_pts_, parameter_.min_pts_);
-    
-    parameter_.max_pts_ = 30;
-    nh.param("cluster_max_pts", parameter_.max_pts_, parameter_.max_pts_);
-    
-    parameter_.min_keypoint_separation_ = 0.1;
-    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, parameter_.min_keypoint_separation_);
+    nh.param("cluster_max_distance", parameter_.max_distance_, 0.4);
+    nh.param("cluster_min_pts", parameter_.min_pts_, 2);
+    nh.param("cluster_max_pts", parameter_.max_pts_, 30);
+    nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, 0.1);
     parameter_buffered_ = parameter_;
     
-    concave_hull_depth_ = 2.0;
-    nh.param("concave_hull_depth", concave_hull_depth_, concave_hull_depth_);
+    nh.param("concave_hull_depth", concave_hull_depth_, 2.0);
     
     // setup dynamic reconfigure
     dynamic_recfg_ = new dynamic_reconfigure::Server<CostmapToPolygonsDBSConcaveHullConfig>(nh);

--- a/test/costmap_polygons.cpp
+++ b/test/costmap_polygons.cpp
@@ -1,0 +1,125 @@
+#include <random>
+#include <memory>
+#include <gtest/gtest.h>
+
+#include <costmap_converter/costmap_to_polygons.h>
+
+// make things accesible in the test
+class CostmapToPolygons : public costmap_converter::CostmapToPolygonsDBSMCCH
+{
+  public:
+    const std::vector<costmap_converter::CostmapToPolygonsDBSMCCH::KeyPoint>& points() const {return occupied_cells_;}
+    costmap_converter::CostmapToPolygonsDBSMCCH::Parameters& parameters() {return parameter_;}
+    using costmap_converter::CostmapToPolygonsDBSMCCH::addPoint;
+    using costmap_converter::CostmapToPolygonsDBSMCCH::regionQuery;
+    using costmap_converter::CostmapToPolygonsDBSMCCH::dbScan;
+    using costmap_converter::CostmapToPolygonsDBSMCCH::convexHull2;
+};
+
+class CostmapToPolygonsDBSMCCHTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override {
+      // parameters
+      costmap_to_polygons.parameters().max_distance_ = 0.5;
+      costmap_to_polygons.parameters().max_pts_ = 100;
+      costmap_to_polygons.parameters().min_pts_ = 2;
+      costmap_to_polygons.parameters().min_keypoint_separation_ = 0.1;
+
+      costmap.reset(new costmap_2d::Costmap2D(100, 100, 0.1, -5., -5.));
+      costmap_to_polygons.setCostmap2D(costmap.get());
+
+      std::random_device rand_dev;
+      std::mt19937 generator(rand_dev());
+      std::uniform_real_distribution<> random_angle(-M_PI, M_PI);
+      std::uniform_real_distribution<> random_dist(0.,   costmap_to_polygons.parameters().max_distance_);
+
+      costmap_to_polygons.addPoint(0., 0.);
+      costmap_to_polygons.addPoint(1.3, 1.3);
+
+      // adding random points
+      double center_x = costmap_to_polygons.points()[0].x;
+      double center_y = costmap_to_polygons.points()[0].y;
+      for (int i = 0; i < costmap_to_polygons.parameters().max_pts_ - 1; ++i)
+      {
+        double alpha = random_angle(generator);
+        double dist  = random_dist(generator);
+        double wx = center_x + std::cos(alpha) * dist;
+        double wy = center_y + std::sin(alpha) * dist;
+        costmap_to_polygons.addPoint(wx, wy);
+      }
+
+      // some noisy points not belonging to a cluster
+      costmap_to_polygons.addPoint(-1, -1);
+      costmap_to_polygons.addPoint(-2, -2);
+      
+      // adding random points
+      center_x = costmap_to_polygons.points()[1].x;
+      center_y = costmap_to_polygons.points()[1].y;
+      for (int i = 0; i < costmap_to_polygons.parameters().max_pts_/2; ++i)
+      {
+        double alpha = random_angle(generator);
+        double dist  = random_dist(generator);
+        double wx = center_x + std::cos(alpha) * dist;
+        double wy = center_y + std::sin(alpha) * dist;
+        costmap_to_polygons.addPoint(wx, wy);
+      }
+    }
+
+    void regionQueryTrivial(int curr_index, std::vector<int>& neighbor_indices)
+    {
+      neighbor_indices.clear();
+      const auto& query_point = costmap_to_polygons.points()[curr_index];
+      for (int i = 0; i < int(costmap_to_polygons.points().size()); ++i)
+      {
+        if (i == curr_index)
+          continue;
+        const auto& kp = costmap_to_polygons.points()[i];
+        double dx = query_point.x - kp.x;
+        double dy = query_point.y - kp.y;
+        double dist = sqrt(dx*dx + dy*dy);
+        if (dist < costmap_to_polygons.parameters().max_distance_)
+          neighbor_indices.push_back(i);
+      }
+    }
+
+    CostmapToPolygons costmap_to_polygons;
+    std::shared_ptr<costmap_2d::Costmap2D> costmap;
+};
+
+TEST_F(CostmapToPolygonsDBSMCCHTest, regionQuery)
+{
+  std::vector<int> neighbors, neighbors_trivial;
+  costmap_to_polygons.regionQuery(0, neighbors);
+  regionQueryTrivial(0, neighbors_trivial);
+  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_ - 1, int(neighbors.size()));
+  ASSERT_EQ(neighbors_trivial.size(), neighbors.size());
+  std::sort(neighbors.begin(), neighbors.end());
+  ASSERT_EQ(neighbors_trivial, neighbors);
+
+  costmap_to_polygons.regionQuery(1, neighbors);
+  regionQueryTrivial(1, neighbors_trivial);
+  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_/2, int(neighbors.size()));
+  ASSERT_EQ(neighbors_trivial.size(), neighbors.size());
+  std::sort(neighbors.begin(), neighbors.end());
+  ASSERT_EQ(neighbors_trivial, neighbors);
+}
+
+TEST_F(CostmapToPolygonsDBSMCCHTest, dbScan)
+{
+  std::vector< std::vector<costmap_converter::CostmapToPolygonsDBSMCCH::KeyPoint> > clusters;
+  costmap_to_polygons.dbScan(clusters);
+  
+  ASSERT_EQ(3, clusters.size());
+  ASSERT_EQ(2, clusters[0].size()); // noisy points not belonging to a cluster
+  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_, clusters[1].size()); // first cluster at (0,0)
+  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_/2 + 1, clusters[2].size()); // second cluster at (1,1)
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "CostmapConverterTester");
+  ros::NodeHandle nh;
+  return RUN_ALL_TESTS();
+}

--- a/test/costmap_polygons.cpp
+++ b/test/costmap_polygons.cpp
@@ -116,6 +116,19 @@ TEST_F(CostmapToPolygonsDBSMCCHTest, dbScan)
   ASSERT_EQ(costmap_to_polygons.parameters().max_pts_/2 + 1, clusters[2].size()); // second cluster at (1,1)
 }
 
+TEST(CostmapToPolygonsDBSMCCH, EmptyMap)
+{
+  std::shared_ptr<costmap_2d::Costmap2D> costmap =
+    std::make_shared<costmap_2d::Costmap2D>(costmap_2d::Costmap2D(100, 100, 0.1, -5., -5.));
+  CostmapToPolygons costmap_to_polygons;
+  costmap_to_polygons.setCostmap2D(costmap.get());
+
+  std::vector< std::vector<costmap_converter::CostmapToPolygonsDBSMCCH::KeyPoint> > clusters;
+  costmap_to_polygons.dbScan(clusters);
+  ASSERT_EQ(1, clusters.size());    // noise cluster exists
+  ASSERT_EQ(0, clusters[0].size()); // noise clsuter is empty
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- introduce a grid look up structure for speeding up regionQuery
  - replace brute for regionQuery
  - add a mutexed parameter struct to avoid parameter updates while computing
  - on my PC / enviroment: 350ms (before) -> 50ms (after)
- add test cases for regionQuery and dbScan in CostmapToPolygonsDBSMCCH