### PR TITLE
Fix compilation error in tests for Foxy

### DIFF
--- a/costmap_converter/test/costmap_polygons.cpp
+++ b/costmap_converter/test/costmap_polygons.cpp
@@ -122,10 +122,10 @@ TEST_F(CostmapToPolygonsDBSMCCHTest, dbScan)
   std::vector< std::vector<costmap_converter::CostmapToPolygonsDBSMCCH::KeyPoint> > clusters;
   costmap_to_polygons.dbScan(clusters);
   
-  ASSERT_EQ(3, clusters.size());
-  ASSERT_EQ(2, clusters[0].size()); // noisy points not belonging to a cluster
-  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_, clusters[1].size()); // first cluster at (0,0)
-  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_/2 + 1, clusters[2].size()); // second cluster at (1,1)
+  ASSERT_EQ(3u, clusters.size());
+  ASSERT_EQ(2u, clusters[0].size()); // noisy points not belonging to a cluster
+  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_, static_cast<int>(clusters[1].size())); // first cluster at (0,0)
+  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_/2 + 1,  static_cast<int>(clusters[2].size())); // second cluster at (1,1)
 }
 
 TEST(CostmapToPolygonsDBSMCCH, EmptyMap)
@@ -137,8 +137,8 @@ TEST(CostmapToPolygonsDBSMCCH, EmptyMap)
 
   std::vector< std::vector<costmap_converter::CostmapToPolygonsDBSMCCH::KeyPoint> > clusters;
   costmap_to_polygons.dbScan(clusters);
-  ASSERT_EQ(1, clusters.size());    // noise cluster exists
-  ASSERT_EQ(0, clusters[0].size()); // noise clsuter is empty
+  ASSERT_EQ(1u, clusters.size());    // noise cluster exists
+  ASSERT_EQ(0u, clusters[0].size()); // noise clsuter is empty
 }
 
 TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
@@ -154,7 +154,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
   // degenerate case with just two points
   geometry_msgs::msg::Polygon original_polygon = polygon;
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(2, polygon.points.size());
+  ASSERT_EQ(2u, polygon.points.size());
   for (size_t i = 0; i < polygon.points.size(); ++i)
   {
     ASSERT_FLOAT_EQ(original_polygon.points[i].x, polygon.points[i].x);
@@ -165,7 +165,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
   polygon.points.push_back(create_point(1., simplification_threshold / 2.));
   original_polygon = polygon;
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(3, polygon.points.size());
+  ASSERT_EQ(3u, polygon.points.size());
   for (size_t i = 0; i < polygon.points.size(); ++i)
   {
     ASSERT_FLOAT_EQ(original_polygon.points[i].x, polygon.points[i].x);
@@ -177,7 +177,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
   // remove the point that has to be removed by the simplification
   original_polygon.points.erase(original_polygon.points.begin()+2);
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(3, polygon.points.size());
+  ASSERT_EQ(3u, polygon.points.size());
   for (size_t i = 0; i < polygon.points.size(); ++i)
   {
     ASSERT_FLOAT_EQ(original_polygon.points[i].x, polygon.points[i].x);
@@ -208,7 +208,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygonPerfectLines)
     polygon.points.push_back(create_point(lastPoint.x + i * 1., lastPoint.y));
 
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(6, polygon.points.size());
+  ASSERT_EQ(6u, polygon.points.size());
   ASSERT_FLOAT_EQ(  0., polygon.points[0].x);
   ASSERT_FLOAT_EQ(  0., polygon.points[0].y);
   ASSERT_FLOAT_EQ(100., polygon.points[1].x);


### PR DESCRIPTION
Hi,

Some warning in Eloquent are errors in Foxy, due to the compiler version. This fixes the error.

Best

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>