### PR TITLE
Assign nullptr to spin_thread_ after deletion

### DIFF
--- a/costmap_converter/include/costmap_converter/costmap_converter_interface.h
+++ b/costmap_converter/include/costmap_converter/costmap_converter_interface.h
@@ -225,6 +225,7 @@ public:
         }
         spin_thread_->join();
         delete spin_thread_;
+        spin_thread_ = nullptr;
       }
     }
 


### PR DESCRIPTION
In class [BaseCostmapToPolygons](https://github.com/rst-tu-dortmund/costmap_converter/blob/e8c1d2c8c8d5e34b1980062e28e4a4dc1817bade/include/costmap_converter/costmap_converter_interface.h#L77), spin_thread_ pointer variable [is used to check if thread should be stopped and join](https://github.com/rst-tu-dortmund/costmap_converter/blob/e8c1d2c8c8d5e34b1980062e28e4a4dc1817bade/include/costmap_converter/costmap_converter_interface.h#L213).
After deletion in stopWorker ptr was [never set to nullptr](https://github.com/rst-tu-dortmund/costmap_converter/blob/e8c1d2c8c8d5e34b1980062e28e4a4dc1817bade/include/costmap_converter/costmap_converter_interface.h#L220), so second call to stopWorker blocks forever.
This bug prevent TEB planner from being used in lifecycle node, because BaseCostmapToPolygons cannot be stopped then [destructed](https://github.com/rst-tu-dortmund/costmap_converter/blob/e8c1d2c8c8d5e34b1980062e28e4a4dc1817bade/include/costmap_converter/costmap_converter_interface.h#L90).

Solution is to set spin_thread_ to null after deletion. In future, it will be more reliable to use smart pointers instead of raw.

