### PR TITLE
Provide always frame_id on visual markers

### DIFF
--- a/src/costmap_converter_node.cpp
+++ b/src/costmap_converter_node.cpp
@@ -134,9 +134,7 @@ public:
 
       obstacle_pub_.publish(obstacles);
 
-      frame_id_ = msg->header.frame_id;
-
-      publishAsMarker(frame_id_, *obstacles, marker_pub_);
+      publishAsMarker(msg->header.frame_id, *obstacles, marker_pub_);
   }
 
   void costmapUpdateCallback(const map_msgs::OccupancyGridUpdateConstPtr& update)
@@ -161,7 +159,7 @@ public:
 
     obstacle_pub_.publish(obstacles);
 
-    publishAsMarker(frame_id_, *obstacles, marker_pub_);
+    publishAsMarker(update->header.frame_id, *obstacles, marker_pub_);
   }
 
   void publishAsMarker(const std::string& frame_id, const std::vector<geometry_msgs::PolygonStamped>& polygonStamped, ros::Publisher& marker_pub)
@@ -274,7 +272,6 @@ private:
   ros::Publisher obstacle_pub_;
   ros::Publisher marker_pub_;
 
-  std::string frame_id_;
   int occupied_min_value_;
 
   costmap_2d::Costmap2D map_;


### PR DESCRIPTION
Otherwise RViz fails to show the visual markers most of the time