### PR TITLE
Fix high CPU usage

### DIFF
--- a/costmap_converter/include/costmap_converter/costmap_converter_interface.h
+++ b/costmap_converter/include/costmap_converter/costmap_converter_interface.h
@@ -242,6 +242,7 @@ protected:
      */
     void spinThread()
     {
+      rclcpp::WallRate r(10);
       while (rclcpp::ok())
       {
         {
@@ -249,6 +250,7 @@ protected:
           if (need_to_terminate_)
             break;
           rclcpp::spin_some(nh_);
+          r.sleep();
         }
       }
     }

--- a/costmap_converter/src/costmap_to_polygons.cpp
+++ b/costmap_converter/src/costmap_to_polygons.cpp
@@ -215,10 +215,12 @@ void CostmapToPolygonsDBSMCCH::updateCostmap2D()
       for (auto& n : neighbor_lookup_)
         n.clear();
 
+      auto size_x = costmap_->getSizeInCellsX();
+      auto size_y = costmap_->getSizeInCellsY();
       // get indices of obstacle cells
-      for(std::size_t i = 0; i < costmap_->getSizeInCellsX(); i++)
+      for(std::size_t i = 0; i < size_x; i++)
       {
-        for(std::size_t j = 0; j < costmap_->getSizeInCellsY(); j++)
+        for(std::size_t j = 0; j < size_y; j++)
         {
           int value = costmap_->getCost(i,j);
           if(value >= nav2_costmap_2d::LETHAL_OBSTACLE)

--- a/costmap_converter/test/costmap_polygons.cpp
+++ b/costmap_converter/test/costmap_polygons.cpp
@@ -122,10 +122,10 @@ TEST_F(CostmapToPolygonsDBSMCCHTest, dbScan)
   std::vector< std::vector<costmap_converter::CostmapToPolygonsDBSMCCH::KeyPoint> > clusters;
   costmap_to_polygons.dbScan(clusters);
   
-  ASSERT_EQ(3, clusters.size());
-  ASSERT_EQ(2, clusters[0].size()); // noisy points not belonging to a cluster
-  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_, clusters[1].size()); // first cluster at (0,0)
-  ASSERT_EQ(costmap_to_polygons.parameters().max_pts_/2 + 1, clusters[2].size()); // second cluster at (1,1)
+  ASSERT_EQ((unsigned)3, clusters.size());
+  ASSERT_EQ((unsigned)2, clusters[0].size()); // noisy points not belonging to a cluster
+  ASSERT_EQ((unsigned)costmap_to_polygons.parameters().max_pts_, clusters[1].size()); // first cluster at (0,0)
+  ASSERT_EQ((unsigned)costmap_to_polygons.parameters().max_pts_/2 + 1, clusters[2].size()); // second cluster at (1,1)
 }
 
 TEST(CostmapToPolygonsDBSMCCH, EmptyMap)
@@ -137,8 +137,8 @@ TEST(CostmapToPolygonsDBSMCCH, EmptyMap)
 
   std::vector< std::vector<costmap_converter::CostmapToPolygonsDBSMCCH::KeyPoint> > clusters;
   costmap_to_polygons.dbScan(clusters);
-  ASSERT_EQ(1, clusters.size());    // noise cluster exists
-  ASSERT_EQ(0, clusters[0].size()); // noise clsuter is empty
+  ASSERT_EQ((unsigned)1, clusters.size());    // noise cluster exists
+  ASSERT_EQ((unsigned)0, clusters[0].size()); // noise clsuter is empty
 }
 
 TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
@@ -154,7 +154,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
   // degenerate case with just two points
   geometry_msgs::msg::Polygon original_polygon = polygon;
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(2, polygon.points.size());
+  ASSERT_EQ((unsigned)2, polygon.points.size());
   for (size_t i = 0; i < polygon.points.size(); ++i)
   {
     ASSERT_FLOAT_EQ(original_polygon.points[i].x, polygon.points[i].x);
@@ -165,7 +165,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
   polygon.points.push_back(create_point(1., simplification_threshold / 2.));
   original_polygon = polygon;
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(3, polygon.points.size());
+  ASSERT_EQ((unsigned)3, polygon.points.size());
   for (size_t i = 0; i < polygon.points.size(); ++i)
   {
     ASSERT_FLOAT_EQ(original_polygon.points[i].x, polygon.points[i].x);
@@ -177,7 +177,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygon)
   // remove the point that has to be removed by the simplification
   original_polygon.points.erase(original_polygon.points.begin()+2);
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(3, polygon.points.size());
+  ASSERT_EQ((unsigned)3, polygon.points.size());
   for (size_t i = 0; i < polygon.points.size(); ++i)
   {
     ASSERT_FLOAT_EQ(original_polygon.points[i].x, polygon.points[i].x);
@@ -208,7 +208,7 @@ TEST(CostmapToPolygonsDBSMCCH, SimplifyPolygonPerfectLines)
     polygon.points.push_back(create_point(lastPoint.x + i * 1., lastPoint.y));
 
   costmap_to_polygons.simplifyPolygon(polygon);
-  ASSERT_EQ(6, polygon.points.size());
+  ASSERT_EQ((unsigned)6, polygon.points.size());
   ASSERT_FLOAT_EQ(  0., polygon.points[0].x);
   ASSERT_FLOAT_EQ(  0., polygon.points[0].y);
   ASSERT_FLOAT_EQ(100., polygon.points[1].x);


### PR DESCRIPTION
We noticed that the costmap converter was using a lot of CPU. We boiled it down to the `spinThread` function. Adding a rate sleep improved CPU usage by around 5x!

I also tried to simply call `rclcpp::spin(nh_);` in `spinThread` and it also reduced CPU usage. I'm not sure `spin_some` is meant to be called in a full-speed loop.