### PR TITLE
fix: invalid new-expression of abstract class type ‘BlobDetector’

### DIFF
--- a/src/costmap_to_dynamic_obstacles/blob_detector.cpp
+++ b/src/costmap_to_dynamic_obstacles/blob_detector.cpp
@@ -6,7 +6,7 @@ BlobDetector::BlobDetector(const SimpleBlobDetector::Params& parameters) : param
 
 cv::Ptr<BlobDetector> BlobDetector::create(const cv::SimpleBlobDetector::Params& params)
 {
-  return cv::Ptr<BlobDetector> (new BlobDetector(params)); // compatibility with older versions
+  return cv::Ptr<BlobDetector> (BlobDetector::create(params)); // compatibility with older versions
   //return cv::makePtr<BlobDetector>(params);
 }
 


### PR DESCRIPTION
On archlinux and nixos I had to apply this change to make the package build.